### PR TITLE
ENV Additions for Nix Builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ include = ["StereoKit/tools/include", "/README.md"]
 readme = "README.md"
 
 [features]
-default = ["event-loop", "local-deps"]
+default = ["event-loop", "force-local-deps"]
 dynamic-openxr = [] # Add openxr_loader.so in Android APK
 build-dynamic-openxr = [
   "dynamic-openxr",
 ] # Build openxr_loader from Khronos OpenXR project
 event-loop = ["dep:winit"]
-local-deps = ["openxr-sys/linked"]
+force-local-deps = ["openxr-sys/linked"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ include = ["StereoKit/tools/include", "/README.md"]
 readme = "README.md"
 
 [features]
-default = ["event-loop"]
+default = ["event-loop", "local-deps"]
 dynamic-openxr = [] # Add openxr_loader.so in Android APK
 build-dynamic-openxr = [
   "dynamic-openxr",
 ] # Build openxr_loader from Khronos OpenXR project
 event-loop = ["dep:winit"]
+local-deps = ["openxr-sys/linked"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,12 @@ include = ["StereoKit/tools/include", "/README.md"]
 readme = "README.md"
 
 [features]
-default = ["event-loop", "force-local-deps"]
+default = ["event-loop"]
 dynamic-openxr = [] # Add openxr_loader.so in Android APK
 build-dynamic-openxr = [
   "dynamic-openxr",
 ] # Build openxr_loader from Khronos OpenXR project
 event-loop = ["dep:winit"]
-force-local-deps = ["openxr-sys/linked"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dynamic-openxr = [] # Add openxr_loader.so in Android APK
 build-dynamic-openxr = [ "dynamic-openxr",] # Build openxr_loader from Khronos OpenXR project
 event-loop = ["dep:winit"]
 no-event-loop = ["dep:android-activity"]
+force-local-deps = ["openxr-sys/linked"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,8 @@ fn main() {
 
     if cfg!(feature = "force-local-deps") {
         cmake_config.define("CPM_USE_LOCAL_PACKAGES", "ON");
-        cmake_config.define("CPM_FORCE_LOCAL_PACKAGES", "ON");
+        cmake_config.define("CPM_LOCAL_PACKAGES_ONLY", "ON");
+        cmake_config.define("CPM_DOWNLOAD_ALL", "OFF");
     }
 
     cmake_config.define("SK_BUILD_SHARED_LIBS", "OFF");

--- a/build.rs
+++ b/build.rs
@@ -19,17 +19,13 @@ fn main() {
     // Build StereoKit, and tell rustc to link it.
     let mut cmake_config = Config::new("StereoKit");
 
-    if var("FORCE_LOCAL_DEPS").ok().is_some() {
+    if cfg!(feature = "force-local-deps") && var("FORCE_LOCAL_DEPS").ok().is_some() {
         // Helper function to define optional dependencies
         fn define_if_exists(var_name: &str, cmake_var: &str, config: &mut Config) {
             if let Some(value) = var(var_name).ok() {
                 config.define(cmake_var, value);
             }
         }
-        cmake_config
-            .define("CPM_USE_LOCAL_PACKAGES", "ON")
-            .define("CPM_LOCAL_PACKAGES_ONLY", "ON")
-            .define("CPM_DOWNLOAD_ALL", "OFF");
 
         define_if_exists("DEP_OPENXR_LOADER_SOURCE", "CPM_openxr_loader_SOURCE", &mut cmake_config);
         define_if_exists("DEP_MESHOPTIMIZER_SOURCE", "CPM_meshoptimizer_SOURCE", &mut cmake_config);

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,10 @@ fn main() {
     // Build StereoKit, and tell rustc to link it.
     let mut cmake_config = cmake::Config::new("StereoKit");
 
+    if cfg!(feature = "local-deps") {
+        cmake_config.define("CPM_USE_LOCAL_PACKAGES", "ON");
+    }
+
     cmake_config.define("SK_BUILD_SHARED_LIBS", "OFF");
     cmake_config.define("SK_BUILD_TESTS", "OFF");
     cmake_config.define("SK_PHYSICS", "OFF");

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,7 @@ fn main() {
 
     if cfg!(feature = "local-deps") {
         cmake_config.define("CPM_USE_LOCAL_PACKAGES", "ON");
+        cmake_config.define("CPM_FORCE_LOCAL_PACKAGES", "ON");
     }
 
     cmake_config.define("SK_BUILD_SHARED_LIBS", "OFF");

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
     // Build StereoKit, and tell rustc to link it.
     let mut cmake_config = cmake::Config::new("StereoKit");
 
-    if cfg!(feature = "local-deps") {
+    if cfg!(feature = "force-local-deps") {
         cmake_config.define("CPM_USE_LOCAL_PACKAGES", "ON");
         cmake_config.define("CPM_FORCE_LOCAL_PACKAGES", "ON");
     }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::{env, fs, path::Path};
+use cmake::Config;
 
 macro_rules! cargo_link {
     ($feature:expr) => {
@@ -7,8 +8,8 @@ macro_rules! cargo_link {
 }
 
 fn main() {
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let target_os = var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_family = var("CARGO_CFG_TARGET_FAMILY").unwrap();
 
     if target_os == "macos" {
         println!("cargo:warning=You seem to be building for MacOS! We still enable builds so that rust-analyzer works, but this won't actually build StereoKit so it'll be pretty non-functional.");
@@ -16,25 +17,38 @@ fn main() {
     }
 
     // Build StereoKit, and tell rustc to link it.
-    let mut cmake_config = cmake::Config::new("StereoKit");
+    let mut cmake_config = Config::new("StereoKit");
 
-    if cfg!(feature = "force-local-deps") {
-        cmake_config.define("CPM_USE_LOCAL_PACKAGES", "ON");
-        cmake_config.define("CPM_LOCAL_PACKAGES_ONLY", "ON");
-        cmake_config.define("CPM_DOWNLOAD_ALL", "OFF");
+    if var("FORCE_LOCAL_DEPS").ok().is_some() {
+        // Helper function to define optional dependencies
+        fn define_if_exists(var_name: &str, cmake_var: &str, config: &mut Config) {
+            if let Some(value) = var(var_name).ok() {
+                config.define(cmake_var, value);
+            }
+        }
+        cmake_config
+            .define("CPM_USE_LOCAL_PACKAGES", "ON")
+            .define("CPM_LOCAL_PACKAGES_ONLY", "ON")
+            .define("CPM_DOWNLOAD_ALL", "OFF");
+
+        define_if_exists("DEP_OPENXR_LOADER_SOURCE", "CPM_openxr_loader_SOURCE", &mut cmake_config);
+        define_if_exists("DEP_MESHOPTIMIZER_SOURCE", "CPM_meshoptimizer_SOURCE", &mut cmake_config);
+        define_if_exists("DEP_BASIS_UNIVERSAL_SOURCE", "CPM_basis_universal_SOURCE", &mut cmake_config);
+        define_if_exists("DEP_SK_GPU_SOURCE", "CPM_sk_gpu_SOURCE", &mut cmake_config);
     }
 
-    cmake_config.define("SK_BUILD_SHARED_LIBS", "OFF");
-    cmake_config.define("SK_BUILD_TESTS", "OFF");
-    cmake_config.define("SK_PHYSICS", "OFF");
+    cmake_config
+        .define("SK_BUILD_SHARED_LIBS", "OFF")
+        .define("SK_BUILD_TESTS", "OFF")
+        .define("SK_PHYSICS", "OFF");
     if target_os == "android" {
-        cmake_config.define("CMAKE_ANDROID_API", "32");
-        cmake_config.define("CMAKE_INSTALL_INCLUDEDIR", "install");
-        cmake_config.define("CMAKE_INSTALL_LIBDIR", "install");
+        cmake_config.define("CMAKE_ANDROID_API", "32")
+            .define("CMAKE_INSTALL_INCLUDEDIR", "install")
+            .define("CMAKE_INSTALL_LIBDIR", "install");
         if cfg!(feature = "build-dynamic-openxr") {
             // When you need to build and use Khronos openxr loader use this feature:
-            cmake_config.define("SK_DYNAMIC_OPENXR", "ON");
-            cmake_config.define("SK_BUILD_OPENXR_LOADER", "ON");
+            cmake_config.define("SK_DYNAMIC_OPENXR", "ON")
+                .define("SK_BUILD_OPENXR_LOADER", "ON");
         } else if cfg!(feature = "dynamic-openxr") {
             // When you need to ship your own openxr loader use this feature:
             cmake_config.define("SK_DYNAMIC_OPENXR", "ON");
@@ -105,8 +119,7 @@ fn main() {
                 if cfg!(feature = "build-dynamic-openxr") {
                     let file_so = dst.join("lib/libopenxr_loader.so");
                     let _lib_o = fs::copy(file_so, dest_file_so).unwrap();
-                } else if let Err(_e) = fs::remove_file(dest_file_so) {
-                }
+                } else if let Err(_e) = fs::remove_file(dest_file_so) {}
             } else {
                 cargo_link!("X11");
                 cargo_link!("Xfixes");


### PR DESCRIPTION
Allows for forcing inclusion of local dependencies instead of using CPM-downloaded ones via ENVs, to allow nix builds